### PR TITLE
Drop weird alt-text on image in PULL_REQUEST_TEMPLATE

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@
 <!-- Please fill in your description above the --- -->
 <!-- Protip, use a descriptive way such as https://cucumber.io/docs/gherkin/reference/ -->
 Please read [using git](https://github.com/unacast/.github/blob/main/USING_GIT.md) and `contributing guidelines` ⤵️ before submitting code. (It's at the bottom of the page)
-<img width="506" alt="Screenshot 2022-08-19 at 09 46 50" src="https://user-images.githubusercontent.com/4453/185570224-76924708-8f95-4409-8ebb-f373d0dfaa5f.png">
+<img width="506" src="https://user-images.githubusercontent.com/4453/185570224-76924708-8f95-4409-8ebb-f373d0dfaa5f.png">


### PR DESCRIPTION
The "Screenshot 2022-08-19 at 09 46 50"-alt text on the image in the template is just weird.

---
<!-- Please fill in your description above the --- -->
<!-- Protip, use a descriptive way such as https://cucumber.io/docs/gherkin/reference/ -->
Please read [using git](https://github.com/unacast/.github/blob/main/USING_GIT.md) and `contributing guidelines` ⤵️ before submitting code. (It's at the bottom of the page)
<img width="506" alt="Screenshot 2022-08-19 at 09 46 50" src="https://user-images.githubusercontent.com/4453/185570224-76924708-8f95-4409-8ebb-f373d0dfaa5f.png">
